### PR TITLE
Relocated dependency

### DIFF
--- a/proto/rpcfour.pb.go
+++ b/proto/rpcfour.pb.go
@@ -4,7 +4,7 @@
 
 package proto
 
-import proto1 "code.google.com/p/goprotobuf/proto"
+import proto1 "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 

--- a/rpc4go/codec.go
+++ b/rpc4go/codec.go
@@ -8,7 +8,7 @@ import (
 	"net"
 	"net/rpc"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	rpc4 "github.com/contester/rpc4/proto"
 )
 


### PR DESCRIPTION
"code.google.com/p/goprotobuf/proto" has moved to "github.com/golang/protobuf/proto"
Updated go import paths to reflect this change.